### PR TITLE
Update CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,3 +1,1 @@
-2018.caipyra.python.org.br
 caipyra.python.org.br
-www.caipyra.python.org.br


### PR DESCRIPTION
Não é mais possível configurar mais de um subdomínio no CNAME. Voltando para caipyra.python.org.br.